### PR TITLE
Builds for 1.21.4, 1.21.5 & 1.21.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6-SNAPSHOT'
+	id 'fabric-loom' version '1.10-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,14 @@ dependencies {
 
 processResources {
 	inputs.property "version", project.version
+	inputs.property "minecraft_version", project.minecraft_version
+	inputs.property "loader_version", project.loader_version
+	filteringCharset "UTF-8"
 
 	filesMatching("fabric.mod.json") {
-		expand "version": project.version
+		expand "version": project.version,
+				"minecraft_version": project.minecraft_version,
+				"loader_version": project.loader_version
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.6
-yarn_mappings=1.20.6+build.1
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.8
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.0.2
+mod_version=1.0.3
 maven_group=io.github.andyrusso.dynamicfireoverlay
 archives_base_name=dynamic-fire-overlay
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ org.gradle.parallel=true
 # check these on https://fabricmc.net/develop
 minecraft_version=1.20.6
 yarn_mappings=1.20.6+build.1
-loader_version=0.15.11
+loader_version=0.16.10
 
 # Mod Properties
 mod_version=1.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.0.3
+mod_version=1.0.4
 maven_group=io.github.andyrusso.dynamicfireoverlay
 archives_base_name=dynamic-fire-overlay
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -14,8 +14,8 @@
 		"dynamic-fire-overlay.mixins.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.15.6",
-		"minecraft": ">=1.20.5",
+		"fabricloader": ">=${loader_version}",
+		"minecraft": "${minecraft_version}",
 		"java": ">=21"
 	}
 }


### PR DESCRIPTION
For some reason 1.20.6 build is not working starting from 1.21.4 (1.21.1 and 1.21.3 working fine). So I explicitly built for 1.21.4+: https://github.com/PukPukov/dynamic-fire-overlay/releases/tag/v1.0.4 (but for security reasons you might want to manually build it from HEAD~1 for 1.21.4 and HEAD for 1.21.5)